### PR TITLE
統一了eslint的格式規定

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -22,7 +22,7 @@ EXPOSE ${PORT}
 
 # 啟動應用程式 |設定預設執行指令
 # 用 nodemon 啟動伺服器
-#CMD ["nodemon", "bin/www.js"]
+# CMD ["nodemon", "bin/www.js"]
 
 # 容器 PostgreSQL 起來之後，後端才會啟動
 CMD ["sh", "-c", "node wait-for-postgres.js && npx nodemon bin/www.js"]


### PR DESCRIPTION
- 加入在commit前eslint會協助檢查程式碼是否有console.log ，如果有，會被擋下來，要把console.log都改成console.warn或是直接使用logger
- 這樣統一了協作格式語法，也提早避免到時候要部屬環境時，誤把console.log也部署到正式環境 會洩漏資料